### PR TITLE
Jody/multiple train cars

### DIFF
--- a/main.js
+++ b/main.js
@@ -68,37 +68,48 @@ export class Main extends Scene {
         const t = program_state.animation_time / 1000, dt = program_state.animation_delta_time / 1000;
         let model_transform = Mat4.identity();
             
+        // train dimensions
         const depth = 7;
         const length = 25;
+        const height = 12;
+
+        // train object translation factors
+        const bar_depth = 2 - depth;
+        const seat_depth = 1.5 - depth;
+        const door_length = 38 - length;
+        const inner_bar_length = 34.5 - length;
+        const outer_bar_length = 41.5 - length;
+        const outer_seat_length = length - 4.6;
+
         // Displaying custom objects
-        this.ground.render(context, program_state, depth * 2, length * 2, -0.5);
-        this.ceiling.render(context, program_state, 5, depth * 2, length * 2, 11.75);
+        this.ground.render(context, program_state, depth * 2, length * 2);
+        this.ceiling.render(context, program_state, 5, depth * 2, length * 2, height);
         // opposite side
-        this.wall.render(context, program_state, length, 5, 3, -1.5, Mat4.translation(0, -.5, 1.5 - depth));
-        this.car_end.render(context, program_state, depth * 2, 12, 10.75, Mat4.translation(-length, -.5, 0).times(Mat4.rotation(Math.PI / 2, 0, 1, 0)));
+        this.wall.render(context, program_state, length, 5, 3, -depth);
+        this.car_end.render(context, program_state, depth * 2, height, 10, Mat4.translation(-length, 0, 0).times(Mat4.rotation(Math.PI / 2, 0, 1, 0)));
         this.handlebars.render(context, program_state, t, Math.atan(this.acceleration/9.8), this.trainMove, 13, length * 2, Mat4.translation(0, 9, 2 - depth));
-        this.vertical_bar.render(context, program_state, 12, Mat4.translation(34.5 - length, 5.5, 2 - depth));
-        this.vertical_bar.render(context, program_state, 12, Mat4.translation(-(34.5 - length), 5.5, 2 - depth));
-        this.vertical_bar.render(context, program_state, 12, Mat4.translation(41.5 - length, 5.5, 2 - depth));
-        this.vertical_bar.render(context, program_state, 12, Mat4.translation(-(41.5 - length), 5.5, 2 - depth));
-        this.seat.render(context, program_state, 8.5, Mat4.translation(0, 0, 1.5 - depth));
-        this.seat.render(context, program_state, 3, Mat4.translation(length - 4.6, 0, 1.5 - depth));
-        this.seat.render(context, program_state, 3, Mat4.translation(-(length - 4.6), 0, 1.5 - depth));
-        this.doors.render(context, program_state, 10, 0.25, Mat4.translation(38 - length, 0, -depth)); // feel free to experiment with the parameters
-        this.doors.render(context, program_state, 10, 0.25, Mat4.translation(-(38 - length), 0, -depth));
+        this.vertical_bar.render(context, program_state, height, Mat4.translation(inner_bar_length, height / 2, bar_depth));
+        this.vertical_bar.render(context, program_state, height, Mat4.translation(-inner_bar_length, height / 2, bar_depth));
+        this.vertical_bar.render(context, program_state, height, Mat4.translation(outer_bar_length, height / 2, bar_depth));
+        this.vertical_bar.render(context, program_state, height, Mat4.translation(-outer_bar_length, height / 2, bar_depth));
+        this.seat.render(context, program_state, 8.5, Mat4.translation(0, 0, seat_depth));
+        this.seat.render(context, program_state, 3, Mat4.translation(outer_seat_length, 0, seat_depth));
+        this.seat.render(context, program_state, 3, Mat4.translation(-outer_seat_length, 0, seat_depth));
+        this.doors.render(context, program_state, 10, 0.25, Mat4.translation(door_length, 0, -depth)); // feel free to experiment with the parameters
+        this.doors.render(context, program_state, 10, 0.25, Mat4.translation(-door_length, 0, -depth));
 
         // other side
-        this.wall.render(context, program_state, length, 5, 3, -1.5, Mat4.scale(1, 1, -1).times(Mat4.translation(0, -.5, 1.5 - depth)));
-        this.car_end.render(context, program_state, depth * 2, 12, 10.75, Mat4.translation(length, -.5, 0).times(Mat4.rotation(Math.PI / 2, 0, 1, 0)));
+        this.wall.render(context, program_state, length, 5, 3, depth);
+        this.car_end.render(context, program_state, depth * 2, height, 10, Mat4.translation(length, 0, 0).times(Mat4.rotation(Math.PI / 2, 0, 1, 0)));
         this.handlebars.render(context, program_state, t, Math.atan(this.acceleration/9.8), this.trainMove, 13, length * 2, Mat4.scale(1, 1, -1).times(Mat4.translation(0, 9, 2 - depth)));
-        this.vertical_bar.render(context, program_state, 12, Mat4.scale(1, 1, -1).times(Mat4.translation(34.5 - length, 5.5, 2 - depth)));
-        this.vertical_bar.render(context, program_state, 12, Mat4.scale(1, 1, -1).times(Mat4.translation(-(34.5 - length), 5.5, 2 - depth)));
-        this.vertical_bar.render(context, program_state, 12, Mat4.scale(1, 1, -1).times(Mat4.translation(41.5 - length, 5.5, 2 - depth)));
-        this.vertical_bar.render(context, program_state, 12, Mat4.scale(1, 1, -1).times(Mat4.translation(-(41.5 - length), 5.5, 2 - depth)));
-        this.seat.render(context, program_state, 8.5, Mat4.scale(1, 1, -1).times(Mat4.translation(0, 0, 1.5 - depth)));
-        this.seat.render(context, program_state, 3, Mat4.scale(1, 1, -1).times(Mat4.translation(length - 4.6, 0, 1.5 - depth)));
-        this.seat.render(context, program_state, 3, Mat4.scale(1, 1, -1).times(Mat4.translation(-(length - 4.6), 0, 1.5 - depth)));
-        this.doors.render(context, program_state, 10, 0.25, Mat4.scale(1, 1, -1).times(Mat4.translation(38 - length, 0, -depth))); // feel free to experiment with the parameters
-        this.doors.render(context, program_state, 10, 0.25, Mat4.scale(1, 1, -1).times(Mat4.translation(-(38 - length), 0, -depth)));
+        this.vertical_bar.render(context, program_state, height, Mat4.scale(1, 1, -1).times(Mat4.translation(inner_bar_length, height / 2, bar_depth)));
+        this.vertical_bar.render(context, program_state, height, Mat4.scale(1, 1, -1).times(Mat4.translation(-inner_bar_length, height / 2, bar_depth)));
+        this.vertical_bar.render(context, program_state, height, Mat4.scale(1, 1, -1).times(Mat4.translation(outer_bar_length, height / 2, bar_depth)));
+        this.vertical_bar.render(context, program_state, height, Mat4.scale(1, 1, -1).times(Mat4.translation(-outer_bar_length, height / 2, bar_depth)));
+        this.seat.render(context, program_state, 8.5, Mat4.scale(1, 1, -1).times(Mat4.translation(0, 0, seat_depth)));
+        this.seat.render(context, program_state, 3, Mat4.scale(1, 1, -1).times(Mat4.translation(outer_seat_length, 0, seat_depth)));
+        this.seat.render(context, program_state, 3, Mat4.scale(1, 1, -1).times(Mat4.translation(-outer_seat_length, 0, seat_depth)));
+        this.doors.render(context, program_state, 10, 0.25, Mat4.scale(1, 1, -1).times(Mat4.translation(door_length, 0, -depth))); // feel free to experiment with the parameters
+        this.doors.render(context, program_state, 10, 0.25, Mat4.scale(1, 1, -1).times(Mat4.translation(-door_length, 0, -depth)));
     }
 }

--- a/main.js
+++ b/main.js
@@ -48,6 +48,63 @@ export class Main extends Scene {
         });
     }
 
+    render_train_cars(context, program_state, num_cars=3, space_btwn_cars=5) {
+        const t = program_state.animation_time / 1000;
+
+        // train dimensions
+        const depth = 7;
+        const length = 25;
+        const height = 12;
+
+        // train object translation factors
+        const bar_depth = 2 - depth;
+        const seat_depth = 1.5 - depth;
+        const door_length = 38 - length;
+        const inner_bar_length = 34.5 - length;
+        const outer_bar_length = 41.5 - length;
+        const outer_seat_length = length - 4.6;
+
+        for(let i = 0; i < num_cars; i++) {
+
+            // train car translation factors
+            const train_car_translation = Mat4.translation(i * (length * 2 + space_btwn_cars), 0, 0);
+
+            // Displaying custom objects
+            this.ground.render(context, program_state, depth * 2, length * 2, 0, train_car_translation);
+            this.ceiling.render(context, program_state, 5, depth * 2, length * 2, height, train_car_translation);
+
+            // opposite side
+            this.wall.render(context, program_state, length, 5, 3, -depth, train_car_translation);
+            this.car_end.render(context, program_state, depth * 2, height, 10, train_car_translation.times(Mat4.translation(-length, 0, 0)).times(Mat4.rotation(Math.PI / 2, 0, 1, 0)));
+            this.handlebars.render(context, program_state, t, Math.atan(this.acceleration/9.8), this.trainMove, 13, length * 2, train_car_translation.times(Mat4.translation(0, 9, 2 - depth)));
+            this.vertical_bar.render(context, program_state, height, train_car_translation.times(Mat4.translation(inner_bar_length, height / 2, bar_depth)));
+            this.vertical_bar.render(context, program_state, height, train_car_translation.times(Mat4.translation(-inner_bar_length, height / 2, bar_depth)));
+            this.vertical_bar.render(context, program_state, height, train_car_translation.times(Mat4.translation(outer_bar_length, height / 2, bar_depth)));
+            this.vertical_bar.render(context, program_state, height, train_car_translation.times(Mat4.translation(-outer_bar_length, height / 2, bar_depth)));
+            this.seat.render(context, program_state, 8.5, train_car_translation.times(Mat4.translation(0, 0, seat_depth)));
+            this.seat.render(context, program_state, 3, train_car_translation.times(Mat4.translation(outer_seat_length, 0, seat_depth)));
+            this.seat.render(context, program_state, 3, train_car_translation.times(Mat4.translation(-outer_seat_length, 0, seat_depth)));
+            this.doors.render(context, program_state, 10, 0.25, train_car_translation.times(Mat4.translation(door_length, 0, -depth)));
+            this.doors.render(context, program_state, 10, 0.25, train_car_translation.times(Mat4.translation(-door_length, 0, -depth)));
+
+            // other side
+            this.wall.render(context, program_state, length, 5, 3, depth, train_car_translation);
+            this.car_end.render(context, program_state, depth * 2, height, 10, train_car_translation.times(Mat4.translation(length, 0, 0)).times(Mat4.rotation(Math.PI / 2, 0, 1, 0)));
+            this.handlebars.render(context, program_state, t, Math.atan(this.acceleration/9.8), this.trainMove, 13, length * 2, train_car_translation.times(Mat4.scale(1, 1, -1)).times(Mat4.translation(0, 9, 2 - depth)));
+            this.vertical_bar.render(context, program_state, height, train_car_translation.times(Mat4.scale(1, 1, -1)).times(Mat4.translation(inner_bar_length, height / 2, bar_depth)));
+            this.vertical_bar.render(context, program_state, height, train_car_translation.times(Mat4.scale(1, 1, -1)).times(Mat4.translation(-inner_bar_length, height / 2, bar_depth)));
+            this.vertical_bar.render(context, program_state, height, train_car_translation.times(Mat4.scale(1, 1, -1)).times(Mat4.translation(outer_bar_length, height / 2, bar_depth)));
+            this.vertical_bar.render(context, program_state, height, train_car_translation.times(Mat4.scale(1, 1, -1)).times(Mat4.translation(-outer_bar_length, height / 2, bar_depth)));
+            this.seat.render(context, program_state, 8.5, train_car_translation.times(Mat4.scale(1, 1, -1)).times(Mat4.translation(0, 0, seat_depth)));
+            this.seat.render(context, program_state, 3, train_car_translation.times(Mat4.scale(1, 1, -1)).times(Mat4.translation(outer_seat_length, 0, seat_depth)));
+            this.seat.render(context, program_state, 3, train_car_translation.times(Mat4.scale(1, 1, -1)).times(Mat4.translation(-outer_seat_length, 0, seat_depth)));
+            this.doors.render(context, program_state, 10, 0.25, train_car_translation.times(Mat4.scale(1, 1, -1)).times(Mat4.translation(door_length, 0, -depth)));
+            this.doors.render(context, program_state, 10, 0.25, train_car_translation.times(Mat4.scale(1, 1, -1)).times(Mat4.translation(-door_length, 0, -depth)));
+
+        }
+        
+    }
+
     display(context, program_state) {
         // display():  Called once per frame of animation.
         // Setup -- This part sets up the scene's overall camera matrix, projection matrix, and lights:
@@ -68,48 +125,6 @@ export class Main extends Scene {
         const t = program_state.animation_time / 1000, dt = program_state.animation_delta_time / 1000;
         let model_transform = Mat4.identity();
             
-        // train dimensions
-        const depth = 7;
-        const length = 25;
-        const height = 12;
-
-        // train object translation factors
-        const bar_depth = 2 - depth;
-        const seat_depth = 1.5 - depth;
-        const door_length = 38 - length;
-        const inner_bar_length = 34.5 - length;
-        const outer_bar_length = 41.5 - length;
-        const outer_seat_length = length - 4.6;
-
-        // Displaying custom objects
-        this.ground.render(context, program_state, depth * 2, length * 2);
-        this.ceiling.render(context, program_state, 5, depth * 2, length * 2, height);
-        // opposite side
-        this.wall.render(context, program_state, length, 5, 3, -depth);
-        this.car_end.render(context, program_state, depth * 2, height, 10, Mat4.translation(-length, 0, 0).times(Mat4.rotation(Math.PI / 2, 0, 1, 0)));
-        this.handlebars.render(context, program_state, t, Math.atan(this.acceleration/9.8), this.trainMove, 13, length * 2, Mat4.translation(0, 9, 2 - depth));
-        this.vertical_bar.render(context, program_state, height, Mat4.translation(inner_bar_length, height / 2, bar_depth));
-        this.vertical_bar.render(context, program_state, height, Mat4.translation(-inner_bar_length, height / 2, bar_depth));
-        this.vertical_bar.render(context, program_state, height, Mat4.translation(outer_bar_length, height / 2, bar_depth));
-        this.vertical_bar.render(context, program_state, height, Mat4.translation(-outer_bar_length, height / 2, bar_depth));
-        this.seat.render(context, program_state, 8.5, Mat4.translation(0, 0, seat_depth));
-        this.seat.render(context, program_state, 3, Mat4.translation(outer_seat_length, 0, seat_depth));
-        this.seat.render(context, program_state, 3, Mat4.translation(-outer_seat_length, 0, seat_depth));
-        this.doors.render(context, program_state, 10, 0.25, Mat4.translation(door_length, 0, -depth)); // feel free to experiment with the parameters
-        this.doors.render(context, program_state, 10, 0.25, Mat4.translation(-door_length, 0, -depth));
-
-        // other side
-        this.wall.render(context, program_state, length, 5, 3, depth);
-        this.car_end.render(context, program_state, depth * 2, height, 10, Mat4.translation(length, 0, 0).times(Mat4.rotation(Math.PI / 2, 0, 1, 0)));
-        this.handlebars.render(context, program_state, t, Math.atan(this.acceleration/9.8), this.trainMove, 13, length * 2, Mat4.scale(1, 1, -1).times(Mat4.translation(0, 9, 2 - depth)));
-        this.vertical_bar.render(context, program_state, height, Mat4.scale(1, 1, -1).times(Mat4.translation(inner_bar_length, height / 2, bar_depth)));
-        this.vertical_bar.render(context, program_state, height, Mat4.scale(1, 1, -1).times(Mat4.translation(-inner_bar_length, height / 2, bar_depth)));
-        this.vertical_bar.render(context, program_state, height, Mat4.scale(1, 1, -1).times(Mat4.translation(outer_bar_length, height / 2, bar_depth)));
-        this.vertical_bar.render(context, program_state, height, Mat4.scale(1, 1, -1).times(Mat4.translation(-outer_bar_length, height / 2, bar_depth)));
-        this.seat.render(context, program_state, 8.5, Mat4.scale(1, 1, -1).times(Mat4.translation(0, 0, seat_depth)));
-        this.seat.render(context, program_state, 3, Mat4.scale(1, 1, -1).times(Mat4.translation(outer_seat_length, 0, seat_depth)));
-        this.seat.render(context, program_state, 3, Mat4.scale(1, 1, -1).times(Mat4.translation(-outer_seat_length, 0, seat_depth)));
-        this.doors.render(context, program_state, 10, 0.25, Mat4.scale(1, 1, -1).times(Mat4.translation(door_length, 0, -depth))); // feel free to experiment with the parameters
-        this.doors.render(context, program_state, 10, 0.25, Mat4.scale(1, 1, -1).times(Mat4.translation(-door_length, 0, -depth)));
+        this.render_train_cars(context, program_state, 2, 3);
     }
 }

--- a/objects/Ceiling.js
+++ b/objects/Ceiling.js
@@ -30,13 +30,19 @@ export default class Ceiling extends CustomObject {
 
       const ceiling_transform = model_transform
                                   .times(Mat4.translation(0, ceiling_height, 0))
-                                  .times(Mat4.scale(ceiling_length / 2, ceiling_thickness, ceiling_width / 2)); // length & width / 2 bc 2x2x2 cube
+                                  .times(Mat4.scale(ceiling_length / 2, ceiling_thickness, ceiling_width / 2)) // length & width / 2 bc 2x2x2 cube
+                                  .times(Mat4.translation(0, 1, 0)) // bottom of ceiling is now at ceiling_height
       
       const light_transforms = [];
       for (let i = 1; i <= num_lights; i++) {
         light_transforms.push(
           model_transform
-            .times(Mat4.translation(0, ceiling_height, 0)) // move cylinder to ceiling
+            // get lights to ceiling and back into standard cartesian coordinates
+            .times(Mat4.translation(0, ceiling_height, 0))
+            .times(Mat4.scale(1, ceiling_thickness, 1))
+            .times(Mat4.translation(0, 1, 0)) // up to this point: same as ceiling transform
+            .times(Mat4.scale(1, 1 / ceiling_thickness, 1)) // unscale y-axis to return to standard coordinates
+            // space out lights
             .times(Mat4.translation(-ceiling_length / 2, 0, 0)) // start drawing from edge of ceiling
             .times(Mat4.translation( i * ceiling_length /(num_lights + 1), 0, 0)) // space lights evenly across ceiling
             .times(Mat4.scale(2, 0.5, 2)) // size the cylinder

--- a/objects/Ground.js
+++ b/objects/Ground.js
@@ -30,13 +30,14 @@ export default class Ground extends CustomObject {
     }
 
     /* Custom object functions */
-    render(context, program_state, ground_width=10, ground_length=40, ground_height=20, model_transform=Mat4.identity(), ) {
+    render(context, program_state, ground_width=10, ground_length=40, ground_height=0, model_transform=Mat4.identity(), ) {
       const ground_thickness = 0.15;
 
       const ground_transform = model_transform
                                   .times(Mat4.translation(0, ground_height, 0))
-                                  .times(Mat4.scale(ground_length / 2, ground_thickness, ground_width / 2)); // length & width / 2 bc 2x2x2 cube
-      // ground                           
+                                  .times(Mat4.scale(ground_length / 2, ground_thickness, ground_width / 2)) // length & width / 2 bc 2x2x2 cube
+                                  .times(Mat4.translation(0, -1, 0))
+    //   ground                   
       this.shapes.cube.draw(context, program_state, ground_transform, this.materials.ground);
     }
 }

--- a/objects/Seat.js
+++ b/objects/Seat.js
@@ -30,12 +30,17 @@ export default class Seat extends CustomObject {
         const base_height = .4;
         const base_percentage = .95;
 
-        const cushion_transform = model_transform.times(Mat4.scale(seat_width, seat_thickness, base_depth))
+        const cushion_transform = model_transform
+            .times(Mat4.translation(0, base_height, 0)) // translate up so bottom of base is at (0, 0, 0)
+            .times(Mat4.scale(seat_width, seat_thickness, base_depth))
             .times(Mat4.translation(0, base_height / seat_thickness + 1, 0));
-        const back_rest_transform = model_transform.times(Mat4.scale(seat_width, back_rest_height, seat_thickness))
+        const back_rest_transform = model_transform
+            .times(Mat4.translation(0, base_height, 0)) // translate up so bottom of base is at (0, 0, 0)
+            .times(Mat4.scale(seat_width, back_rest_height, seat_thickness))
             .times(Mat4.translation(0, base_height / back_rest_height + 1, -(base_depth / seat_thickness + 1)));
-        const base_transform = model_transform.times(Mat4.scale(seat_width * base_percentage, base_height, base_depth * base_percentage))
-            .times(Mat4.translation(0, 0, -1 * seat_thickness))
+        const base_transform = model_transform
+            .times(Mat4.scale(seat_width * base_percentage, base_height, base_depth * base_percentage))
+            .times(Mat4.translation(0, 1, -1 * seat_thickness)) // translate up so bottom of base at (0, 0, 0)
 
         const maroon = hex_color("#800000")
         const brown = hex_color("#765c48");


### PR DESCRIPTION
Fixes #31 
A few changes:

**`Ground.js`**: 
* Adjusted transformation so top of ground is at 0.

**`Ceiling.js`**: 
* Adjusted transformation so bottom of ceiling is at the `ceiling_height` specified.

**`Seat.js`**:
* Adjusted transformation so bottom of base of seat is at 0.

**custom object transformations in `main.js`**: 
* Cleaned up some of the numbers in accordance to the new ground and ceiling locations.
* Moved out some redundant translation calculations into variables for convenience if we want to adjust them later

**Helper function to draw extra train cars**:
* _Good News_: Can now draw multiple train cars
* _Bad News_: Drawing more than 2 cars makes my laptop wanna die. 

We can probably optimize by moving a lot of the custom object transformations (aka the ones in the `render()` function) to the constructor so that they're only computed once. Only issue would be, we'd now have to pass parameters as constructors parameters instead, which might take some work to get reorganized. 